### PR TITLE
Add captain command, captain countdown

### DIFF
--- a/main.go
+++ b/main.go
@@ -67,9 +67,8 @@ func main() {
 	ctx := context.Background()
 	client := createClient(ctx, botname)
 	defer client.Close()
-
 	channels := make(map[string]*Channel)
-	games := make(map[GameIdentifier]Game)
+	games := make(map[GameIdentifier]*Game)
 
 	iter := client.Collection("channels").Documents(ctx)
 	for {
@@ -85,7 +84,7 @@ func main() {
 		channels[doc.Ref.ID] = &c
 		for name := range c.Mods {
 			g := GameIdentifier{doc.Ref.ID, name}
-			games[g] = Game{Players: make(map[string]*PlayerMetadata), Red: make(map[string]bool), Blue: make(map[string]bool), mutex: new(sync.Mutex), RedCaptain: new(string), BlueCaptain: new(string)}
+			games[g] = &Game{Players: make(map[string]*PlayerMetadata), Red: make(map[string]bool), Blue: make(map[string]bool), mutex: new(sync.Mutex), RedCaptain: new(string), BlueCaptain: new(string)}
 		}
 	}
 	s := gocron.NewScheduler()


### PR DESCRIPTION
Bot's games map now holds pointers to Game structs to prevent shenanigans
Add .captain command - currently sets the user as a captain of the first game it finds that the user is eligible to be a captain in
A ticker starts when a game fills with similar functionality to the Python bot

Will be working on picking by username, @username, or number next.